### PR TITLE
Fix bracket highlighting in unfocused cells

### DIFF
--- a/codemirror/lib/codemirror.css
+++ b/codemirror/lib/codemirror.css
@@ -93,8 +93,10 @@
 
 .cm-invalidchar {color: #f00;}
 
-div.CodeMirror span.CodeMirror-matchingbracket {color: #0f0;}
-div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
+/* Add .selected selector here to only show matching bracket styling on the 
+   current cell. */
+.cell.selected div.CodeMirror span.CodeMirror-matchingbracket {color: #0f0;}
+.cell.selected div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 
 /* STOP */
 


### PR DESCRIPTION
Should fix the bracket highlighting issue noted in https://github.com/ipython/ipython/issues/3472. This is really more of an issue with CodeMirror itself but I went ahead and created this fix.
